### PR TITLE
fix(template): adjust `DB_SSLMODE`

### DIFF
--- a/internal/app/tmpl/.env.tmpl
+++ b/internal/app/tmpl/.env.tmpl
@@ -11,7 +11,7 @@ DB_PORT={{ .Database.Port }}
 DB_USER={{ .Database.Username }}
 DB_PASS={{ .Database.Password }}
 DB_NAME={{ .Database.DBName }}
-DB_SSLMODE=disable
+DB_SSL_MODE=disable
 DB_MAXCONNECTIONPOOL=4 # number of connections = ((core_count * 2) + effective_spindle_count)
 
 REDIS_HOST=0.0.0.0


### PR DESCRIPTION
Fix template env variables from `DB_SSLMODE` to `DB_SSL_MODE`. Which causing this issue:

```shell
error: pq: SSL is not enabled on the server
task: Failed to run task "migrate": exit status 1
```